### PR TITLE
找不到MySQLdb 官方解法方案，产生新问题解法

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ WeBASE将区块链应用开发标准化，搭建完fisco bcos节点后，只需�
 
 ## 社区
 联系我们：webase@webank.com
+


### PR DESCRIPTION
遇到问题

1、找不到MySQLdb
Traceback (most recent call last):
...
ImportError: No module named MySQLdb

2、官方解法
sudo apt-get install -y python-pip
sudo pip install MySQL-python

3、产生新的问题
解决 Command "python setup.py egg_info" failed with error code 1 问题

4、最新解法

在执行 pip install -r requirements.txt 时遇到错误：
Command "python setup.py egg_info" failed with error code 1

解决方法是更新 setuptools 和 pip：
pip install --upgrade setuptools
python -m pip install --upgrade pip